### PR TITLE
fix comma delimited columns in data frames

### DIFF
--- a/R/countries.R
+++ b/R/countries.R
@@ -149,11 +149,11 @@ as.data.frame.openaq_countries_list <- function(x, row.names = NULL, optional = 
       code = rw$code,
       datetime_first = parse_openaq_timestamp(rw$datetimeFirst),
       datetime_last = parse_openaq_timestamp(rw$datetimeLast),
-      parameter_ids = paste(lapply(rw$parameters, function(x) {
-        rw$id
+      parameter_ids = paste(lapply(rw$parameters, function(p) {
+        p$id
       }), collapse = ","),
-      parameter_names = paste(lapply(rw$parameters, function(x) {
-        paste(rw$name, rw$units, collapse = " ")
+      parameter_names = paste(lapply(rw$parameters, function(p) {
+        paste(p$name, p$units, collapse = " ")
       }), collapse = ",")
     )
   }))

--- a/R/manufacturers.R
+++ b/R/manufacturers.R
@@ -136,8 +136,8 @@ as.data.frame.openaq_manufacturers_list <- function(x, row.names = NULL, optiona
     data.frame(
       id = rw$id,
       name = rw$name,
-      instruments_ids = paste(lapply(rw$instruments, function(x) {
-        rw$id
+      instruments_ids = paste(lapply(rw$instruments, function(i) {
+        i$id
       }), collapse = ",")
     )
   }))

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -112,7 +112,7 @@ list_parameters <- function(
 
 #' Method for converting openaq_parameters_list to data frame.
 #'
-#' @param x A list of countries as returned from list_parameters.
+#' @param x A list of parameters as returned from list_parameters.
 #' @param row.names `NULL` or a character vector giving the row names for the
 #' data frame. Missing values are not allowed.
 #' @param optional logical. If TRUE, setting row names and converting column
@@ -126,8 +126,8 @@ list_parameters <- function(
 #' @export
 #'
 #' @examplesIf interactive()
-#' instruments <- list_instruments()
-#' openaq_parameters_list.as.data.frame(instruments)
+#' parameters <- list_parameters()
+#' openaq_parameters_list.as.data.frame(parameters)
 #'
 as.data.frame.openaq_parameters_list <- function(x, row.names = NULL, optional = FALSE, ...) { # nolint: object_name_linter
   tbl <- do.call(rbind, lapply(x, function(rw) {

--- a/R/providers.R
+++ b/R/providers.R
@@ -141,8 +141,8 @@ as.data.frame.openaq_providers_list <- function(x, row.names = NULL, optional = 
       datetime_first = parse_openaq_timestamp(rw$datetimeFirst),
       datetime_last = parse_openaq_timestamp(rw$datetimeLast),
       entities_id = rw$entitiesId,
-      parameters_ids = paste(lapply(rw$parameters, function(x) {
-        rw$id
+      parameters_ids = paste(lapply(rw$parameters, function(p) {
+        p$id
       }), collapse = ",")
     )
   }))


### PR DESCRIPTION
fixes an issue with how fields are seleted in `lapply` when collapsing to comma delimited string for as.data.frame. resolves #8 